### PR TITLE
feat: auto-copy received text to clipboard on 'text-received' event; …

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -110,6 +110,17 @@ async function copyText() {
     }
 }
 
+// Auto-copy helper used when text is received
+async function copyToClipboard(text) {
+    if (!text || !text.trim()) return;
+    try {
+        await navigator.clipboard.writeText(text);
+        console.log('Auto-copied received text to clipboard');
+    } catch (error) {
+        console.error('Auto-copy failed:', error);
+    }
+}
+
 // User-friendly status messages
 function setUserStatus(results) {
     console.log('Debug info:', results);
@@ -398,6 +409,9 @@ async function initializeApp() {
                                 textarea.value = event.payload;
                                 // Update byte counter when text is received
                                 updateByteCounter();
+                                // Auto-copy to clipboard
+                                copyToClipboard(event.payload);
+                                setStatus('Received and copied to clipboard', '#38a169');
                             }
                         });
                         console.log('Event listener set up successfully');


### PR DESCRIPTION
### Title
Auto-copy received text to clipboard on receipt

### Summary
Implements automatic copying of received text to the system clipboard when a `text-received` event is delivered. This reduces one user action by allowing immediate paste after receiving content. The existing manual copy button remains.

### Changes
- Add `copyToClipboard(text)` helper in `dist/main.js`.
- Invoke auto-copy after updating `textarea` in the `text-received` event listener.
- Update status to “Received and copied to clipboard”. No toast UI added.

### Rationale / UX
- Improves recipient UX by eliminating the extra copy action; users can paste right away.
- Maintains current behavior (textarea still updates, manual copy button remains) for familiarity and fallback.

### Testing
1. Run two LanShare instances on the same LAN.
2. From sender, type/paste text into the textarea.
3. On receiver, verify:
   - Textarea updates with the received content.
   - Status shows “Received and copied to clipboard”.
   - Immediately paste (Cmd/Ctrl+V) to confirm clipboard contains received text.

### Notes
- `dist/` is ignored; `dist/main.js` was force-added on this branch to ship the change.
- If we later adopt a different build pipeline, we should move source-controlled frontend files out of `dist/` and generate artifacts at build time.

### Risks
- Clipboard write failures on some environments (rare). The code logs an error and leaves manual copy as fallback.

### Checklist
- [x] Feature behind no new settings; minimal change
- [x] Manual copy button still works
- [x] Tested locally with two instances


